### PR TITLE
Improved Solus support, and other quality of life improvments

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,19 +3,24 @@ These scripts should be able to get you up and running as quickly as possible af
 ## Quick Start
 The script assumes you are `git clone` -ing into your user directory. Each script is named for the associated linux distro. Below is an example of running the Fedora script...which you will need to run as root due to the display firmware file.
 ```bash
-sudo su
 git clone https://github.com/al12gamer/gpdwinlinux.git
 cd gpdwinlinux
-chmod +x fedora_winmax.sh
-./fedora_winmax.sh
+sudo ./fedora_winmax.sh
 ```
 Feel free to look over my bash script if you are uncomfortable running it as root- have had troubles in the past with sudo not properly installing the screen firmware for the win max.
+
+Alternatively, you can simply run:
+
+`sudo ./gpdwinlinux.sh`
+
+This script will detect which distro you are running and attempt to run the correct file for you.
+If you are on a derivative distro such as Pop!_OS, you need to run the script for your parent distro manually.
+This script may point you to the correct script to run, if you are at all unsure.
+
 ### ProtonUpdater And RetroArch
-Run these as a normal user.
 If you want the awesome [ProtonUpdater](https://copr.fedorainfracloud.org/coprs/david35mm/ProtonUpdater/) package on Fedora so that you can just run `ProtonUpdater` in terminal when you want to check for a newer version of GloriousEggroll's forks of Valve Proton, along with RetroArch, please run 
 ```
 cd gpdwinlinux
-chmod +x fedora_extras.sh
-./fedora_extras.sh
+sudo ./fedora_extras.sh
 ```
 The Ubuntu Extras script installs Proton fixes and the [Proton GE Updater](https://github.com/die-zuckerschnecke/proton-ge-custom-updater), as well as adds the PPA for RetroArch and installs it.

--- a/fedora_extras.sh
+++ b/fedora_extras.sh
@@ -1,5 +1,9 @@
-#!/usr/bin/env bash
-
+#!/bin/bash
+if [ "$UID" != "0" ]; then
+	echo "ERROR: NOT RUNNING AS ROOT!"
+	echo "Please run this script as root to have it work correctly!"
+	exit 2
+fi
 # add flathub and retroarch
 echo "Adding flathub, installing RetroArch"
 sleep .5

--- a/fedora_extras.sh
+++ b/fedora_extras.sh
@@ -13,14 +13,14 @@ flatpak install flathub org.libretro.RetroArch
 # add Proton Updater from COPR
 echo "Grabbing the awesome ProtonUpdater package"
 sleep .5
-sudo dnf copr enable david35mm/ProtonUpdater -y
-sudo dnf update -y
-sudo dnf install ProtonUpdater -y
+dnf copr enable david35mm/ProtonUpdater -y
+dnf update -y
+dnf install ProtonUpdater -y
 
 # add Legendary, open source reimplementation of Epic Games Launcher
 echo "Grabbing an open source implementation of the Epic Games Launcher, Legendary"
 sleep .5
-sudo dnf install legendary -y
+dnf install legendary -y
 
 echo "Script complete! Feel free to exit."
 sleep .5

--- a/fedora_winmax.sh
+++ b/fedora_winmax.sh
@@ -1,5 +1,9 @@
-#!/usr/bin/env bash
-
+#!/bin/bash
+if [ "$UID" != "0" ]; then
+	echo "ERROR: NOT RUNNING AS ROOT!"
+	echo "Please run this script as root to have it work correctly!"
+	exit 2
+fi
 # create firmware file for screen and move to grub
 mkdir /lib/firmware/edid
 base64 --decode ~/gpdwinlinux/winmaxscreen > /lib/firmware/edid/gpdwinmax.bin

--- a/fedora_winmax.sh
+++ b/fedora_winmax.sh
@@ -17,17 +17,24 @@ echo "installing extra repos and gaming packages"
 sleep .5
 dnf install https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm -y
 
+# update repositories
+
+dnf check-update -y
+
 dnf groupupdate core -y
 
 # install some basic stuff you would need otherwise
 dnf install steam lutris wine vim neofetch gamemode gnome-tweaks -y
 
-# update repositories
-
-dnf check-update -y
 
 # upgrade packages
 dnf upgrade -y
 dnf autoremove -y
+
+read -p "Would you like to install the extras? [Y/n]: " ans
+if [ "$ans" == "Y" ] || [ "$ans" == "y" ]; then
+	./fedora_extras.sh
+fi
+
 echo "Script complete, please reboot!"
 sleep 1

--- a/gpdwinlinux.sh
+++ b/gpdwinlinux.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+if [ "$UID" != "0" ]; then
+	echo "ERROR: NOT RUNNING AS ROOT!"
+	echo "Please run this script as root to have it work correctly!"
+	exit 2
+fi
+# Get current distro, in lowercase
+distro=$(lsb_release -is | tr '[:upper:]' '[:lower:]')
+if [ "$distro" == "ubuntu" ]; then
+	./ubuntu_winmax.sh
+elif [ "$distro" == "fedora" ]; then
+	./fedora_winmax.sh
+elif [ "$distro" == "solus" ]; then
+	./solus_winmax.sh
+else
+	# Throw an error for unrecognized distros. Derivative distros will likly do this, so give some error handling text.
+	echo "Distro not recognized!"
+	echo "If your distro uses \`apt', run: sudo ./ubuntu_winmax.sh"
+	echo "If your distro uses \`dnf', run: sudo ./fedora_winmax.sh"
+	echo "If your distro uses \`eopkg', run: sudo ./solus_winmax.sh"
+	exit 2
+fi
+

--- a/solus_winmax.sh
+++ b/solus_winmax.sh
@@ -1,17 +1,22 @@
-
-#!/usr/bin/env bash
-
-# create firmware file for screen and move to grub
-mkdir /lib/firmware/edid
-# Solus USES CLR Instead....need fixing base64 --decode ~/gpdwinlinux/winmaxscreen > /lib/firmware/edid/gpdwinmax.bin
-# change for CLR echo 'GRUB_CMDLINE_LINUX="video=eDP-1:800x1280 drm.edid_firmware=eDP-1:edid/gpdwinmax.bin fbcon=rotate:1"' >> etc/kernel/cmdline
-# clr-boot-manager update
-# echo "GPD Win Max firmware installed"
-# sleep .5
+#!/bin/bash
+if [ "$UID" != "0" ]; then
+	echo "ERROR: NOT RUNNING AS ROOT!"
+	echo "Please run this script as root to have it work correctly!"
+	exit 2
+fi
+# create firmware file for screen, as well as folder to hold command line options and move to CBM
+mkdir -p /lib/firmware/edid /etc/kernel/cmdline.d
+# Standard firmware should work just fine
+base64 --decode ~/gpdwinlinux/winmaxscreen > /lib/firmware/edid/gpdwinmax.bin
+echo 'video=eDP-1:800x1280 drm.edid_firmware=eDP-1:edid/gpdwinmax.bin fbcon=rotate:1' > /etc/kernel/cmdline.d/gpdwinlinux.conf
+clr-boot-manager update
+echo "GPD Win Max firmware installed"
+sleep .5
 
 # install gaming packages and nvidia drivers
 echo "installing steam etc..."
 sleep .5
+eopkg update-repo
 eopkg install steam lutris wine vim neofetch gamemode -y
 
 # update repositories

--- a/ubuntu_extras.sh
+++ b/ubuntu_extras.sh
@@ -7,31 +7,33 @@ fi
 # add retroarch
 echo "Installing RetroArch"
 sleep .5
-sudo add-apt-repository ppa:libretro/stable
-sudo apt update -y && sudo apt install retroarch* -y
+add-apt-repository ppa:libretro/stable
+apt update -y && apt install retroarch* -y
 
 # add protonfixes
 echo "Installing protonfixes"
 sleep .5
-sudo add-apt-repository ppa:jacotsu/protonfixes
-sudo apt update -y && sudo apt install protonfixes -y
+add-apt-repository ppa:jacotsu/protonfixes
+apt update -y && apt install protonfixes -y
 
 # add legendary, OSS Epic Games launcher
 echo "Installing Legendary, an Epic Games Launcher for Linux"
 sleep .5
-sudo apt install python3 python3-requests python3-setuptools-git -y
+apt install python3 python3-requests python3-setuptools-git -y
 git clone https://github.com/derrod/legendary.git
 cd legendary
-sudo python3 setup.py install
+python3 setup.py install
 cd
 
 # add proton-ge-updater
 echo "Grabbing script for updating Proton-GE builds easily"
 sleep .5
-sudo apt install curl unzip -y
+apt install curl unzip -y
 git clone https://github.com/die-zuckerschnecke/proton-ge-custom-updater.git
 cd ~/proton-ge-custom-updater
-bash ./proton-ge-custom-updater.sh
+# We have to use the username for the user we want to become since we are running as root
+# Best way to do that is reading /etc/passwd and getting the username for UID 1000
+su $(grep '1000' /etc/passwd | sed 's/:/ /g' | awk '{print $1}') -c bash ./proton-ge-custom-updater.sh
 echo "In the future, please open the proton-ge-custom-updater folder and run the script if you want a newer GloriousEggroll proton version"
 sleep 1
 echo "Script complete, feel free to exit"

--- a/ubuntu_extras.sh
+++ b/ubuntu_extras.sh
@@ -1,5 +1,9 @@
-#!/usr/bin/env bash
-
+#!/bin/bash
+if [ "$UID" != "0" ]; then
+	echo "ERROR: NOT RUNNING AS ROOT!"
+	echo "Please run this script as root to have it work correctly!"
+	exit 2
+fi
 # add retroarch
 echo "Installing RetroArch"
 sleep .5

--- a/ubuntu_winmax.sh
+++ b/ubuntu_winmax.sh
@@ -1,10 +1,14 @@
-#!/usr/bin/env bash
-
+#!/bin/bash
+if [ "$UID" != "0" ]; then
+	echo "ERROR: NOT RUNNING AS ROOT!"
+	echo "Please run this script as root to have it work correctly!"
+	exit 2
+fi
 # create firmware file for screen and move to grub
 mkdir /lib/firmware/edid
 base64 --decode ~/gpdwinlinux/winmaxscreen > /lib/firmware/edid/gpdwinmax.bin
 echo 'GRUB_CMDLINE_LINUX="video=eDP-1:800x1280 drm.edid_firmware=eDP-1:edid/gpdwinmax.bin fbcon=rotate:1"' >> /etc/default/grub
-sudo update-grub
+update-grub
 echo "GPD Win Max screen firmware installed"
 sleep .5
 

--- a/ubuntu_winmax.sh
+++ b/ubuntu_winmax.sh
@@ -19,12 +19,21 @@ sleep .5
 sudo add-apt-repository ppa:lutris-team/lutris
 
 # install some basic stuff you would need otherwise
-sudo apt update -y
-sudo apt install steam-installer meson lutris vim neofetch gamemode gnome-tweaks -y
+apt update -y
+apt install steam-installer meson lutris gamemode -y
+# Only install gnome-tweaks if Gnome is installed
+if $(dpkg -l *gnome* | grep '^ii' | grep -q 'gnome-shell'); then
+	apt install gnome-tweaks
+fi
 # meson may be needed to build gamemode in the future if it still isn't in main repos
 
 # upgrade packages
-sudo apt update -y && sudo apt upgrade -y
+sudo apt upgrade -y
+
+read -p "Would you like to install the extras? [Y/n]: " ans
+if [ "$ans" == "Y" ] || [ "$ans" == "y" ]; then
+	./ubuntu_extras.sh
+fi
 
 echo "Script complete, please reboot!"
 sleep 1


### PR DESCRIPTION
 * Fixed Solus support
 * Install `gnome-tweaks` only if `gnome-shell` is installed
   * This is only added on Ubuntu as I don't know how to do this on Fedora or Solus. Someone else will need to do that work.
 * Refresh repo cache before installing or updating anything, and only do it once
 * Check if scripts are running as root, throw an error if not
   * Extras files where modified to handle this, and in fact require it now.
 * Create unified front-end, so most users only have to run one file no matter their distro, and it handles figuring out what to do from there.